### PR TITLE
adding --arm64/--amd64 flags to switch docker builds

### DIFF
--- a/util.sh
+++ b/util.sh
@@ -168,7 +168,7 @@ case "$target" in
         ;;
     ## help:command:build build local docker-compose images
     build)
-        compose build
+        compose $@
         ;;
 esac
 


### PR DESCRIPTION
this requires to setup buildx for multi-platform builds
see https://docs.docker.com/build/buildx/multiplatform-images/

also moving $@ handling to top of the file vs inside a function
so that util.sh can manipulate args as necessary

exposing show_help as top-level function