### PR TITLE
allowing to specify compose target in package.json help string

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,123 @@ exit_on_common $@
 `_` are considered private functions and should not be directly used. Other
 functions are allowed to be used. All public functions in the comment above
 have usage example how to use them.
+
+## Help
+
+`util.sh` can also auto-generate help from the both the bash files
+as well as other supporting files.
+
+To see help simply run either:
+
+```bash
+./build.sh help
+./build.sh -h
+./build.sh --help
+```
+
+### Bash
+
+#### commands
+
+Add a comment with the format:
+
+```bash
+## help:command:<commandname> <description>
+```
+
+For example:
+
+```bash
+## help:command:lint run lint checks
+```
+
+#### flags
+
+In addition to documenting commands, flags can be documented as well:
+
+```bash
+## help:flag:<flag> <description>
+```
+
+For example:
+
+```bash
+## help:flag:-v/--verbose show debug logs
+```
+
+### `Makefile`
+
+Each Makefile target can document its help with:
+
+```make
+<target>: ## <description>
+```
+
+For example:
+
+```make
+lint: ## run lint checks
+```
+
+### `package.json`
+
+As this is a json file, to keep syntax valid json, all help strings are
+extracted from the script string itself:
+
+```json
+{
+  "scripts": {
+    "<name>": "<command> ## <description>"
+  }
+}
+```
+
+For example:
+
+```json
+{
+  "scripts": {
+    "lint": "eslint ## run lint checks"
+  }
+}
+```
+
+## Compose Service
+
+`util.sh` can also automatically figure out which compose service should be
+used for the given command. The `service_for_compose ` accepts the default
+service if not override is found. Overrides can be specified like so:
+
+### `Makefile`
+
+```
+<target>: # docker-compose:<service>
+```
+
+For example:
+
+```make
+lint: # docker-compose:precommit
+```
+
+### `package.json`
+
+`docker-compose` service is annotated as part of the help description
+
+```json
+{
+  "scripts": {
+    "<name>": "<command> ## @@docker-compose:<service> <description>"
+  }
+}
+```
+
+For example:
+
+```json
+{
+  "scripts": {
+    "test": "playwright test ## @@docker-compose:tests run UI tests"
+  }
+}
+```


### PR DESCRIPTION
the syntax is:

```json
{
    "scripts": {
        "foo": "bar ## @@docker-compose:baz help description"
    }
}
```

this allows to combine both help text and annotate docker-compose target all in one string