### PR TITLE
adding awsudo utility script

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,20 +8,8 @@ root = true
 end_of_line = lf
 insert_final_newline = true
 
-[Makefile*]
-indent_style = tab
-
-[*.c]
-indent_style = space
 indent_size = 4
-
-[*.py]
 indent_style = space
-indent_size = 4
-
-[*.{yml,yaml}]
-indent_style = space
-indent_size = 2
 
 [*.sh]
 indent_style = space

--- a/bin/assume-role
+++ b/bin/assume-role
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+
+set -eEu
+set -o pipefail
+
+function show_help {
+	echo -e "${YELLOW}$(basename $0)${END_COLOR} [ROLE] [--config] [--shell=*] [-- <CMD>]"
+	echo
+	cat <<EOF
+Wrapper around 'aws sts assume-role'
+
+It allows to either parse result of assume-role and output script to
+set AWS_* env variables:
+
+aws sts assume-role ... | assume-role | eval
+aws sts assume-role ... | assume-role --shell=fish | eval
+
+Alternatively it can output credentials config block:
+
+aws sts assume-role ... | assume-role --config >> ~/.aws/credentials
+
+The wrapper can natively assume role itself as well:
+
+assume-role <ROLE> | eval
+assume-role <ROLE> --config >> ~/.aws/credentials
+
+Finally it can directly exec a command with aws role env vars populated:
+
+assume-role <ROLE> -- ./build.sh deploy
+EOF
+	echo
+	_help_flags $0
+	exit 0
+}
+
+SCRIPTPATH="$(
+	cd $(dirname $(realpath "$0")) >/dev/null 2>&1
+	pwd -P
+)"
+source $SCRIPTPATH/../util.sh
+
+_ensure_aws_profile
+
+if [ -t 0 ]; then
+	role=$1
+	shift
+	if ! [[ "$role" = arn* ]]; then
+		role=arn:aws:iam::$(
+			aws sts get-caller-identity \
+				--query="Account" \
+				--output=text
+		):role/$role
+	fi
+	assumed_role=$(aws sts assume-role --role-arn=$role --role-session-name=$(date +%s))
+else
+	assumed_role=$(cat -)
+fi
+
+region=${AWS_DEFAULT_REGION:-$(aws configure get region)}
+key_id=$(echo $assumed_role | jq -r '.Credentials.AccessKeyId')
+secret_key=$(echo $assumed_role | jq -r '.Credentials.SecretAccessKey')
+session_token=$(echo $assumed_role | jq -r '.Credentials.SessionToken')
+expiration=$(echo $assumed_role | jq -r '.Credentials.Expiration')
+
+function _credentials {
+	cat <<EOF
+[role]
+region = $region
+aws_access_key_id = $key_id
+aws_secret_access_key = $secret_key
+aws_session_token = $session_token
+expiration = $expiration
+EOF
+}
+
+function _env {
+	if [ -n "$export" ]; then
+		export="export "
+	fi
+	case "$shell" in
+	fish)
+		cat <<EOF
+set -gx AWS_DEFAULT_REGION $region
+set -gx AWS_ACCESS_KEY_ID $key_id
+set -gx AWS_SECRET_ACCESS_KEY $secret_key
+set -gx AWS_SESSION_TOKEN $session_token
+EOF
+		;;
+	*)
+		cat <<EOF
+${export}AWS_DEFAULT_REGION=$region
+${export}AWS_ACCESS_KEY_ID=$key_id
+${export}AWS_SECRET_ACCESS_KEY=$secret_key
+${export}AWS_SESSION_TOKEN=$session_token
+EOF
+		;;
+	esac
+}
+
+credentials=
+env=
+export=
+cmd=
+shell=${STARSHIP_SHELL:-bash}
+
+for arg; do
+	shift
+	case "$arg" in
+	## help:flag:--config output ~/.aws/credentials config block
+	## help:flag:--credentials output ~/.aws/credentials config block
+	--config) ;&
+	--credentials)
+		credentials=true
+		;;
+	## help:flag:--shell=* which shell to output env vars
+	--shell=*)
+		shell=${arg##*=}
+		;;
+	## help:flag:-- after delimiter execute command with AWS assumed role
+	--)
+		cmd="$@"
+		export=true
+		break
+		;;
+	*)
+		set -- "$@" "$arg"
+		;;
+	esac
+done
+
+if [ -n "$cmd" ]; then
+	source <(shell=bash _env)
+	exec $cmd
+
+elif [ -n "$credentials" ]; then
+	_credentials
+
+else
+	_env
+
+fi

--- a/bin/awsudo
+++ b/bin/awsudo
@@ -11,15 +11,23 @@ ${IYELLOW}${name}${IEND_COLOR} [ROLE] [--config] [--shell=*] [-- <CMD>]
 
 Wrapper around 'aws sts assume-role'
 
-It allows to either parse result of assume-role and output script to
-set AWS_* env variables:
+It allows to either parse result of assume-role and output script to set
+AWS_* env variables:
 
 aws sts assume-role ... | ${IGREEN}$name${IEND_COLOR} | eval
+
+To customize which shell output is exported use ${IYELLOW}--shell${IEND_COLOR} flag:
+
 aws sts assume-role ... | ${IGREEN}$name --shell=fish${IEND_COLOR} | eval
 
 Alternatively it can output credentials config block:
 
 aws sts assume-role ... | ${IGREEN}$name --config${IEND_COLOR} >> ~/.aws/credentials
+
+It will generate profile config block with a name "role".
+To customize that use ${IYELLOW}--profile${IEND_COLOR} flag:
+
+aws sts assume-role ... | ${IGREEN}$name --config --profile=default${IEND_COLOR} >> ~/.aws/credentials
 
 The wrapper can natively assume role itself as well:
 
@@ -104,6 +112,7 @@ credentials=
 env=
 export=
 cmd=
+profile=role
 shell=${STARSHIP_SHELL:-bash}
 
 for arg; do
@@ -114,6 +123,10 @@ for arg; do
     --config) ;&
     --credentials)
         credentials=true
+        ;;
+    ## help:flag:--profile=* name of profile to export with --config. default is "role"
+    --profile=*)
+        profile=${arg##*=}
         ;;
     ## help:flag:--shell=* which shell to output env vars
     --shell=*)

--- a/bin/awsudo
+++ b/bin/awsudo
@@ -4,9 +4,9 @@ set -eEu
 set -o pipefail
 
 function show_help {
-	echo -e "${YELLOW}$(basename $0)${END_COLOR} [ROLE] [--config] [--shell=*] [-- <CMD>]"
-	echo
-	cat <<EOF
+    echo -e "${YELLOW}$(basename $0)${END_COLOR} [ROLE] [--config] [--shell=*] [-- <CMD>]"
+    echo
+    cat << EOF
 Wrapper around 'aws sts assume-role'
 
 It allows to either parse result of assume-role and output script to
@@ -28,32 +28,32 @@ Finally it can directly exec a command with aws role env vars populated:
 
 assume-role <ROLE> -- ./build.sh deploy
 EOF
-	echo
-	_help_flags $0
-	exit 0
+    echo
+    _help_flags $0
+    exit 0
 }
 
 SCRIPTPATH="$(
-	cd $(dirname $(realpath "$0")) >/dev/null 2>&1
-	pwd -P
+    cd $(dirname $(realpath "$0")) > /dev/null 2>&1
+    pwd -P
 )"
 source $SCRIPTPATH/../util.sh
 
 _ensure_aws_profile
 
 if [ -t 0 ]; then
-	role=$1
-	shift
-	if ! [[ "$role" = arn* ]]; then
-		role=arn:aws:iam::$(
-			aws sts get-caller-identity \
-				--query="Account" \
-				--output=text
-		):role/$role
-	fi
-	assumed_role=$(aws sts assume-role --role-arn=$role --role-session-name=$(date +%s))
+    role=$1
+    shift
+    if ! [[ "$role" = arn* ]]; then
+        role=arn:aws:iam::$(
+            aws sts get-caller-identity \
+                --query="Account" \
+                --output=text
+        ):role/$role
+    fi
+    assumed_role=$(aws sts assume-role --role-arn=$role --role-session-name=$(date +%s))
 else
-	assumed_role=$(cat -)
+    assumed_role=$(cat -)
 fi
 
 region=${AWS_DEFAULT_REGION:-$(aws configure get region)}
@@ -63,7 +63,7 @@ session_token=$(echo $assumed_role | jq -r '.Credentials.SessionToken')
 expiration=$(echo $assumed_role | jq -r '.Credentials.Expiration')
 
 function _credentials {
-	cat <<EOF
+    cat << EOF
 [role]
 region = $region
 aws_access_key_id = $key_id
@@ -74,27 +74,27 @@ EOF
 }
 
 function _env {
-	if [ -n "$export" ]; then
-		export="export "
-	fi
-	case "$shell" in
-	fish)
-		cat <<EOF
+    if [ -n "$export" ]; then
+        export="export "
+    fi
+    case "$shell" in
+        fish)
+            cat << EOF
 set -gx AWS_DEFAULT_REGION $region
 set -gx AWS_ACCESS_KEY_ID $key_id
 set -gx AWS_SECRET_ACCESS_KEY $secret_key
 set -gx AWS_SESSION_TOKEN $session_token
 EOF
-		;;
-	*)
-		cat <<EOF
+            ;;
+        *)
+            cat << EOF
 ${export}AWS_DEFAULT_REGION=$region
 ${export}AWS_ACCESS_KEY_ID=$key_id
 ${export}AWS_SECRET_ACCESS_KEY=$secret_key
 ${export}AWS_SESSION_TOKEN=$session_token
 EOF
-		;;
-	esac
+            ;;
+    esac
 }
 
 credentials=
@@ -104,38 +104,38 @@ cmd=
 shell=${STARSHIP_SHELL:-bash}
 
 for arg; do
-	shift
-	case "$arg" in
-	## help:flag:--config output ~/.aws/credentials config block
-	## help:flag:--credentials output ~/.aws/credentials config block
-	--config) ;&
-	--credentials)
-		credentials=true
-		;;
-	## help:flag:--shell=* which shell to output env vars
-	--shell=*)
-		shell=${arg##*=}
-		;;
-	## help:flag:-- after delimiter execute command with AWS assumed role
-	--)
-		cmd="$@"
-		export=true
-		break
-		;;
-	*)
-		set -- "$@" "$arg"
-		;;
-	esac
+    shift
+    case "$arg" in
+        ## help:flag:--config output ~/.aws/credentials config block
+        ## help:flag:--credentials output ~/.aws/credentials config block
+        --config) ;&
+        --credentials)
+            credentials=true
+            ;;
+        ## help:flag:--shell=* which shell to output env vars
+        --shell=*)
+            shell=${arg##*=}
+            ;;
+        ## help:flag:-- after delimiter execute command with AWS assumed role
+        --)
+            cmd="$@"
+            export=true
+            break
+            ;;
+        *)
+            set -- "$@" "$arg"
+            ;;
+    esac
 done
 
 if [ -n "$cmd" ]; then
-	source <(shell=bash _env)
-	exec $cmd
+    source <(shell=bash _env)
+    exec $cmd
 
 elif [ -n "$credentials" ]; then
-	_credentials
+    _credentials
 
 else
-	_env
+    _env
 
 fi

--- a/bin/awsudo
+++ b/bin/awsudo
@@ -5,37 +5,39 @@ set -o pipefail
 
 function show_help {
     name=$(basename $0)
-    echo -e "${YELLOW}${name}${END_COLOR} [ROLE] [--config] [--shell=*] [-- <CMD>]"
-    echo
-    cat << EOF
+    cat <(
+        cat <<EOF
+${IYELLOW}${name}${IEND_COLOR} [ROLE] [--config] [--shell=*] [-- <CMD>]
+
 Wrapper around 'aws sts assume-role'
 
 It allows to either parse result of assume-role and output script to
 set AWS_* env variables:
 
-aws sts assume-role ... | $name | eval
-aws sts assume-role ... | $name --shell=fish | eval
+aws sts assume-role ... | ${IGREEN}$name${IEND_COLOR} | eval
+aws sts assume-role ... | ${IGREEN}$name --shell=fish${IEND_COLOR} | eval
 
 Alternatively it can output credentials config block:
 
-aws sts assume-role ... | $name --config >> ~/.aws/credentials
+aws sts assume-role ... | ${IGREEN}$name --config${IEND_COLOR} >> ~/.aws/credentials
 
 The wrapper can natively assume role itself as well:
 
-$name <ROLE> | eval
-$name <ROLE> --config >> ~/.aws/credentials
+${IGREEN}$name <ROLE>${IEND_COLOR} | eval
+${IGREEN}$name <ROLE> --config${IEND_COLOR} >> ~/.aws/credentials
 
 Finally it can directly exec a command with aws role env vars populated:
 
-$name <ROLE> -- ./build.sh deploy
+${IGREEN}$name <ROLE> -- ./build.sh deploy${IEND_COLOR}
+
 EOF
-    echo
+    )
     _help_flags $0
     exit 0
 }
 
 SCRIPTPATH="$(
-    cd $(dirname $(realpath "$0")) > /dev/null 2>&1
+    cd $(dirname $(realpath "$0")) >/dev/null 2>&1
     pwd -P
 )"
 source $SCRIPTPATH/../util.sh
@@ -64,7 +66,7 @@ session_token=$(echo $assumed_role | jq -r '.Credentials.SessionToken')
 expiration=$(echo $assumed_role | jq -r '.Credentials.Expiration')
 
 function _credentials {
-    cat << EOF
+    cat <<EOF
 [role]
 region = $region
 aws_access_key_id = $key_id
@@ -79,22 +81,22 @@ function _env {
         export="export "
     fi
     case "$shell" in
-        fish)
-            cat << EOF
+    fish)
+        cat <<EOF
 set -gx AWS_DEFAULT_REGION $region
 set -gx AWS_ACCESS_KEY_ID $key_id
 set -gx AWS_SECRET_ACCESS_KEY $secret_key
 set -gx AWS_SESSION_TOKEN $session_token
 EOF
-            ;;
-        *)
-            cat << EOF
+        ;;
+    *)
+        cat <<EOF
 ${export}AWS_DEFAULT_REGION=$region
 ${export}AWS_ACCESS_KEY_ID=$key_id
 ${export}AWS_SECRET_ACCESS_KEY=$secret_key
 ${export}AWS_SESSION_TOKEN=$session_token
 EOF
-            ;;
+        ;;
     esac
 }
 
@@ -107,25 +109,25 @@ shell=${STARSHIP_SHELL:-bash}
 for arg; do
     shift
     case "$arg" in
-        ## help:flag:--config output ~/.aws/credentials config block
-        ## help:flag:--credentials output ~/.aws/credentials config block
-        --config) ;&
-        --credentials)
-            credentials=true
-            ;;
-        ## help:flag:--shell=* which shell to output env vars
-        --shell=*)
-            shell=${arg##*=}
-            ;;
-        ## help:flag:-- after delimiter execute command with AWS assumed role
-        --)
-            cmd="$@"
-            export=true
-            break
-            ;;
-        *)
-            set -- "$@" "$arg"
-            ;;
+    ## help:flag:--config output ~/.aws/credentials config block
+    ## help:flag:--credentials output ~/.aws/credentials config block
+    --config) ;&
+    --credentials)
+        credentials=true
+        ;;
+    ## help:flag:--shell=* which shell to output env vars
+    --shell=*)
+        shell=${arg##*=}
+        ;;
+    ## help:flag:-- after delimiter execute command with AWS assumed role
+    --)
+        cmd="$@"
+        export=true
+        break
+        ;;
+    *)
+        set -- "$@" "$arg"
+        ;;
     esac
 done
 

--- a/bin/awsudo
+++ b/bin/awsudo
@@ -4,7 +4,8 @@ set -eEu
 set -o pipefail
 
 function show_help {
-    echo -e "${YELLOW}$(basename $0)${END_COLOR} [ROLE] [--config] [--shell=*] [-- <CMD>]"
+    name=$(basename $0)
+    echo -e "${YELLOW}${name}${END_COLOR} [ROLE] [--config] [--shell=*] [-- <CMD>]"
     echo
     cat << EOF
 Wrapper around 'aws sts assume-role'
@@ -12,21 +13,21 @@ Wrapper around 'aws sts assume-role'
 It allows to either parse result of assume-role and output script to
 set AWS_* env variables:
 
-aws sts assume-role ... | assume-role | eval
-aws sts assume-role ... | assume-role --shell=fish | eval
+aws sts assume-role ... | $name | eval
+aws sts assume-role ... | $name --shell=fish | eval
 
 Alternatively it can output credentials config block:
 
-aws sts assume-role ... | assume-role --config >> ~/.aws/credentials
+aws sts assume-role ... | $name --config >> ~/.aws/credentials
 
 The wrapper can natively assume role itself as well:
 
-assume-role <ROLE> | eval
-assume-role <ROLE> --config >> ~/.aws/credentials
+$name <ROLE> | eval
+$name <ROLE> --config >> ~/.aws/credentials
 
 Finally it can directly exec a command with aws role env vars populated:
 
-assume-role <ROLE> -- ./build.sh deploy
+$name <ROLE> -- ./build.sh deploy
 EOF
     echo
     _help_flags $0

--- a/util.sh
+++ b/util.sh
@@ -10,6 +10,11 @@ if [ -n "${NO_COLOR:-}" ]; then
     GREEN=
     END_COLOR=
 fi
+IYELLOW=$(echo -en $YELLOW)
+IBLUE=$(echo -en $BLUE)
+IRED=$(echo -en $RED)
+IGREEN=$(echo -en $GREEN)
+IEND_COLOR=$(echo -en $END_COLOR)
 
 SOURCE=${BASH_SOURCE:-}
 

--- a/util.sh
+++ b/util.sh
@@ -421,10 +421,10 @@ function _help_file_commands {
     fi
     case "$bin" in
         Makefile)
-            _help_makefile
+            _help_file_makefile
             ;;
         package.json)
-            _help_packagejson
+            _help_file_packagejson
             ;;
         *)
             grep -E '^\s*## help:command' $bin \


### PR DESCRIPTION
Wrapper around `aws sts assume-role`

It allows to either parse result of assume-role and output script to

set AWS_* env variables:

```sh
aws sts assume-role ... | awsudo | eval
aws sts assume-role ... | awsudo --shell=fish | eval
```

Alternatively it can output credentials config block:

```sh
aws sts assume-role ... | awsudo --config >> ~/.aws/credentials
```

The wrapper can natively assume role itself as well:

```sh
awsudo <ROLE> | eval
awsudo <ROLE> --config >> ~/.aws/credentials
```

Finally it can directly exec a command with aws role env vars populated:

```sh
awsudo <ROLE> -- ./build.sh deploy
```